### PR TITLE
Binding child should happen in bind no init

### DIFF
--- a/rest_framework/serializers.py
+++ b/rest_framework/serializers.py
@@ -563,10 +563,10 @@ class ListSerializer(BaseSerializer):
         assert self.child is not None, '`child` is a required argument.'
         assert not inspect.isclass(self.child), '`child` has not been instantiated.'
         super(ListSerializer, self).__init__(*args, **kwargs)
-        self.child.bind(field_name='', parent=self)
 
     def bind(self, field_name, parent):
         super(ListSerializer, self).bind(field_name, parent)
+        self.child.bind(field_name='', parent=self)
         self.partial = self.parent.partial
 
     def get_initial(self):


### PR DESCRIPTION
It should fix several issues related to child caching wrong root, the one I was dealing with was that child of a `many=True` serializer didn't have access to context.

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
